### PR TITLE
Fix character encoding

### DIFF
--- a/Revival House/site.html
+++ b/Revival House/site.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <link rel="stylesheet" href="siteCSS.css">
         <title>Bob's movie club</title>
         <script src="siteJS.js"></script>


### PR DESCRIPTION
We must specify an encoding such that accented characters are displayed correctly. We choose UTF-8 as it will generally let us use any character in most known languages.